### PR TITLE
Re-factor dependency management

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,8 +8,7 @@
 
 1. Create a new directory; `cd` into it
 2. `yo cloudfour-core-webapp`
-3. `npm install`
-4. `gulp --tasks`
+3. `gulp --tasks`
 
 # Tests
 

--- a/app/index.js
+++ b/app/index.js
@@ -17,12 +17,19 @@ module.exports = generators.Base.extend({
   prompting: function () {
     var done = this.async();
     this.prompt([{
+      name: 'name',
+      message: 'Project name for package.json',
+      type: 'input',
+      default: 'cloudfour-web-project'
+    },
+    {
       name   : 'templates',
       message: 'Add "html" task and template compilation?',
       type   : 'confirm',
       default: false
     }], function (answers) {
       this.features = {};
+      this.features.name      = answers.name;
       this.features.templates = this.options.templates || answers.templates;
       done();
     }.bind(this));
@@ -53,9 +60,10 @@ module.exports = generators.Base.extend({
       );
     },
     packageJSON: function () {
-      this.fs.copy(
+      this.fs.copyTpl(
         this.templatePath('_package.json'),
-        this.destinationPath('package.json')
+        this.destinationPath('package.json'),
+        this.features
       );
     },
     src: function () {
@@ -64,6 +72,13 @@ module.exports = generators.Base.extend({
         this.destinationRoot() + '/src/'
       );
     }
+  },
+  install: function () {
+    this.npmInstall([
+      'babel-core',
+      'gulp',
+      'cloudfour/core-gulp-tasks'
+    ], { 'saveDev': true });
   },
   end: {
     sayBye: function () {

--- a/app/templates/_package.json
+++ b/app/templates/_package.json
@@ -1,7 +1,6 @@
 {
-  "devDependencies": {
-    "babel-core": "^5.5.6",
-    "core-gulp-tasks": "cloudfour/core-gulp-tasks.git",
-    "gulp": "^3.9.0"
-  }
+  "name": "<%= name %>",
+  "version": "1.0.0",
+  "description": "A Cloud Four web project",
+  "devDependencies": {  }
 }

--- a/package.json
+++ b/package.json
@@ -27,6 +27,9 @@
     "yosay": "^1.0.5"
   },
   "devDependencies": {
-    "mocha": "^2.3.3"
+    "chai": "^3.3.0",
+    "mocha": "^2.3.3",
+    "sinon": "^1.17.1",
+    "sinon-chai": "^2.8.0"
   }
 }

--- a/test/general.js
+++ b/test/general.js
@@ -32,6 +32,12 @@ describe('general', function () {
         'src/main.css'
       ]);
     });
+
+    it('creates a package.json', function () {
+      assert.file('package.json');
+      // Name should be set to default for the associated prompt
+      assert.fileContent('package.json', 'cloudfour-web-project');
+    });
   });
   describe('dependency management', function () {
     var npmStub;

--- a/test/general.js
+++ b/test/general.js
@@ -2,37 +2,58 @@
 var path = require('path');
 var helpers = require('yeoman-generator').test;
 var assert = require('yeoman-assert');
+var chai   = require('chai');
+var sinon  = require('sinon');
+var sinonChai = require('sinon-chai');
+var expect = chai.expect;
+chai.use(sinonChai);
 
 describe('general', function () {
-  before(function (done) {
-    helpers.run(path.join(__dirname, '../app'))
-      .inDir(path.join(__dirname, 'temp'))
-      .on('end', done);
+  describe('core functionality', function () {
+    before(function (done) {
+      helpers.run(path.join(__dirname, '../app'))
+        .inDir(path.join(__dirname, 'temp'))
+        .on('end', done);
+    });
+
+    it('the generator can be required without throwing', function () {
+      // not testing the actual run of generators yet
+      require('../app');
+    });
+
+    it('creates expected files', function () {
+      assert.file([
+        'package.json',
+        'gulp.config.js',
+        'gulpfile.babel.js',
+        '.gitignore',
+        '.node-version',
+        'src/main.js',
+        'src/main.css'
+      ]);
+    });
   });
+  describe('dependency management', function () {
+    var npmStub;
+    beforeEach(function (done) {
+      helpers.run(path.join(__dirname, '../app'))
+        .inDir(path.join(__dirname, 'temp'))
+        .on('ready', function (generator) {
+          // When run in test, generator.npmInstall is a no-op
+          // so we can't test its output. Instead, we'll
+          // stub and make sure it is getting called correctly.
+          npmStub = sinon.stub();
+          generator.npmInstall = npmStub;
+        })
+        .on('end', done);
+    });
+    it('invokes npmInstall for dependencies', function () {
+      var callArgs = npmStub.lastCall.args;
+      expect(npmStub).to.have.been.calledOnce;
+      expect(callArgs).to.have.length(2);
+      expect(callArgs[0]).to.have.members(['gulp','babel-core','cloudfour/core-gulp-tasks']);
+      expect(callArgs[1]).to.have.property('saveDev', true);
+    });
 
-  it('the generator can be required without throwing', function () {
-    // not testing the actual run of generators yet
-    require('../app');
   });
-
-  it('creates expected files', function () {
-    assert.file([
-      'package.json',
-      'gulp.config.js',
-      'gulpfile.babel.js',
-      '.gitignore',
-      '.node-version',
-      'src/main.js',
-      'src/main.css'
-    ]);
-  });
-
-  it('needs to have package.json/npmInstall tested');
-  /**
-   * I believe I can do this by mocking `npmInstall`
-   * the way https://github.com/yeoman/generator-bootstrap/blob/master/test/test.js
-   * mocks `bowerInstall`. And ideally use `sinon` to
-   * spy on how it's invoked.
-   **/
-
 });

--- a/test/general.js
+++ b/test/general.js
@@ -26,4 +26,13 @@ describe('general', function () {
       'src/main.css'
     ]);
   });
+
+  it('needs to have package.json/npmInstall tested');
+  /**
+   * I believe I can do this by mocking `npmInstall`
+   * the way https://github.com/yeoman/generator-bootstrap/blob/master/test/test.js
+   * mocks `bowerInstall`. And ideally use `sinon` to
+   * spy on how it's invoked.
+   **/
+
 });


### PR DESCRIPTION
This PR is the successful result of some investigations this morning.

TIL:
* Using `yeoman-generator`'s API to manage `npmInstall` and the like will not _create_ a `package.json` if one doesn't exist, even with the `{ saveDev: true }` option. The `package.json` has to exist.
* However, we can create a basic template for the `package.json` and manage the actual _dependencies_ using the API. That means—I believe—if we compose another generator with this one, this one is responsible for creating the base `package.json` file itself and installing its _own_ dependencies. The "extending" generator could then add its own dependencies using the API. This feels like a better sanity situation for now.
* It took a little while to figure out how to test the dependency stuff meaningfully, but was a slightly satisfying problem to solve. So, passing tests are included.
* It's no longer necessary to run `npm install` after running the generator, as that is handled for you.