### PR TITLE
Add html watcher when html enabled, tests

### DIFF
--- a/app/templates/gulp.config.js
+++ b/app/templates/gulp.config.js
@@ -55,6 +55,10 @@ config.html = {
   src: `${src}/**/*.hbs`,
   templateExt: 'hbs'
 };
+config.watch.watchers.push({
+    match: [`${src}/**/*.hbs`],
+    tasks: ['html']
+});
 <% } %>
 
 export default config;

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "yosay": "^1.0.5"
   },
   "devDependencies": {
+    "babel": "^5.8.23",
     "chai": "^3.3.0",
     "mocha": "^2.3.3",
     "sinon": "^1.17.1",

--- a/test/templates.js
+++ b/test/templates.js
@@ -2,6 +2,9 @@
 var path = require('path');
 var helpers = require('yeoman-generator').test;
 var assert = require('yeoman-assert');
+var chai   = require('chai');
+var expect = chai.expect;
+require('babel/register');
 
 describe('templates', function () {
   describe('templates enabled via CLI option', function () {
@@ -18,6 +21,14 @@ describe('templates', function () {
 
     it('adds the "html" task config', function () {
       assert.fileContent('gulp.config.js', 'config.html');
+    });
+
+    it('adds the html watcher to the watch task', function () {
+      // Note: Babel transpilation makes this test slower than average
+      var config = require(path.join(__dirname, 'temp/gulp.config.js')),
+        watchers = config.watch.watchers;
+      expect(watchers).to.have.length(2);
+      expect(watchers[1].tasks).to.include('html');
     });
   });
 
@@ -51,6 +62,10 @@ describe('templates', function () {
 
     it('does not add the "html" task config', function () {
       assert.noFileContent('gulp.config.js', 'config.html');
+    });
+
+    it('does not add a watcher for `html` task', function () {
+      assert.noFileContent('gulp.config.js', "['html']");
     });
   });
 


### PR DESCRIPTION
Add `html` watcher when the `html` task is enabled, tests for same.

Fixes #6 
